### PR TITLE
Docker build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# WebAssembly artifacts
+*.wasm

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,0 +1,31 @@
+# dependencies:
+# cargo; cargo wasi; curl; dasel; rustup (we need to add wasm32-wasi target); possibly gcc/g++/binutils/build-base
+FROM rust:alpine
+
+RUN apk update && \
+    apk upgrade --no-cache && \
+    apk add --no-cache curl
+
+
+RUN curl -sSLf "$(curl -sSLf https://api.github.com/repos/tomwright/dasel/releases/latest | grep browser_download_url | grep linux_amd64 | grep -v .gz | cut -d\" -f 4)" -L -o dasel && \
+    chmod +x dasel && \
+    mv ./dasel /bin/dasel
+
+RUN rustup target add wasm32-wasi
+RUN cargo install cargo-wasi
+
+COPY init_script.sh .
+
+WORKDIR /proj
+
+COPY . .
+RUN rm -r ./lib_fl/*
+
+VOLUME ["/lib_fl/"]
+VOLUME ["/out_wasm"]
+
+# copy to destination folder (another mount) with name "code.wasm"
+CMD ["sh", "/init_script.sh"]
+
+
+

--- a/rust/README.md
+++ b/rust/README.md
@@ -10,3 +10,18 @@ Current constraints:
 
 - The crate must be of type `lib`
 - The crate must export one function called `fl_main`, with type `serde_json::Value -> serde_json::Value` (the function can panic, as stderr is captured in the backend)
+
+
+
+# Running the docker image
+
+The docker image requires two volumes:
+
+- The user's function, which will be mounted as `/proj/lib_fl` inside the container
+- An output directory, which will be mounted as `/out_wasm` inside the container
+
+To produce the `code.wasm` for the example function inside the directory `out_wasm`, the run command would be:
+
+```
+docker run -v $(pwd)/lib_fl:/lib_fl/ -v $(pwd)/out_wasm:/out_wasm <IMAGE_NAME>
+```

--- a/rust/init_script.sh
+++ b/rust/init_script.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+cp -r /lib_fl/* /proj/lib_fl/
+echo "$(cat /proj/lib_fl/Cargo.toml | dasel put string -r toml 'package.name' 'lib_fl')" > /proj/lib_fl/Cargo.toml
+cargo wasi build --release
+cp /proj/target/wasm32-wasi/release/wrapper.wasm /out_wasm/code.wasm


### PR DESCRIPTION
This PR adds the Dockerfile and associated initialization script to build and export a generic Rust project, wrapped with the Rust wrapper, as a WebAssembly file.

This closes #3.