### PR TITLE
JS runtime

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -19,6 +19,7 @@ header:
     copyright-owner: Giuseppe De Palma, Matteo Trentin
 
   paths-ignore:
+    - '**/*.json'
     - '**/*.lock'
     - '**/README.md'
     - '**/LICENSE'

--- a/js/.gitignore
+++ b/js/.gitignore
@@ -1,0 +1,3 @@
+.parcel-cache/
+dist/
+node_modules/

--- a/js/Dockerfile
+++ b/js/Dockerfile
@@ -1,0 +1,48 @@
+# Copyright 2022 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+FROM rust:slim as builder
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y cmake git make bash curl clang musl-dev gcc g++
+
+RUN rustup target add wasm32-wasi
+RUN git clone https://github.com/Shopify/javy.git && \
+    cd /javy && \
+    make download-wasi-sdk && \
+    make
+
+##########
+
+FROM node:current-slim
+
+COPY --from=builder /javy/target/release/javy /usr/bin/javy
+
+RUN apt-get update && \
+    apt-get upgrade -y
+
+RUN npm install -g parcel
+
+COPY init_script.sh .
+
+WORKDIR /proj
+
+COPY . .
+RUN rm -r ./lib_fl/*
+
+VOLUME ["/lib_fl/"]
+VOLUME ["/out_wasm"]
+
+
+CMD ["sh", "/init_script.sh"]

--- a/js/README.md
+++ b/js/README.md
@@ -1,0 +1,27 @@
+# Funless wrapper for Javascript functions
+
+This project contains a small wrapper for Javascript functions, ensuring the compatibility with the Wasm runtime in the backend.
+The final Wasm produced receives a JSON string via stdin and returns a JSON string via stdout.
+
+The `lib_fl` folder contains an example Javascript project, respecting the current required constraints for Javascript functions.
+
+
+Current constraints:
+
+- The code must be a valid js library
+- The library must export a `fl_main` function (e.g. `module.exports.fl_main = fl_main`)
+
+
+
+
+# Running the docker image
+
+The docker image requires two volumes:
+
+- The user's function, which will be mounted as `/proj/lib_fl` inside the container
+- An output directory, which will be mounted as `/out_wasm` inside the container
+
+To produce the `code.wasm` for the example function inside the directory `out_wasm`, the run command would be:
+
+```
+docker run -v $(pwd)/lib_fl:/lib_fl/ -v $(pwd)/out_wasm:/out_wasm <IMAGE_NAME>

--- a/js/init_script.sh
+++ b/js/init_script.sh
@@ -1,0 +1,22 @@
+# Copyright 2022 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/bin/sh
+cp -r /lib_fl/* /proj/lib_fl/ &&
+cd /proj/lib_fl &&
+npm install &&
+cd /proj &&
+parcel build --no-source-maps main.js &&
+/usr/bin/javy dist/main.js -o code.wasm &&
+cp /proj/code.wasm /out_wasm/code.wasm

--- a/js/lib_fl/index.js
+++ b/js/lib_fl/index.js
@@ -1,0 +1,21 @@
+// Copyright 2022 Giuseppe De Palma, Matteo Trentin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const _ = require('lodash');
+
+function fl_main(input) {
+    return { payload: "Hello " + (input.name ? input.name : "World") + "!" }
+}
+
+module.exports.fl_main = fl_main;

--- a/js/lib_fl/package.json
+++ b/js/lib_fl/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "lodash": "^4.17.21"
+  }
+}

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,19 @@
+// Copyright 2022 Giuseppe De Palma, Matteo Trentin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var fl_main = require('./lib_fl').fl_main;
+
+Shopify = {
+    main: fl_main
+}


### PR DESCRIPTION
This PR adds the required wrapper, Dockerfile and init script for the building process of JS functions.
An example function is given under the `js/lib_fl` directory.

This closes #11.