### PR TITLE
Update example Rust function

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -12,7 +12,26 @@ checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 name = "lib_fl"
 version = "0.1.0"
 dependencies = [
+ "serde",
  "serde_json",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+dependencies = [
+ "proc-macro2",
 ]
 
 [[package]]
@@ -26,6 +45,20 @@ name = "serde"
 version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.145"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "serde_json"
@@ -37,6 +70,23 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "syn"
+version = "1.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
 
 [[package]]
 name = "wrapper"

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,7 +1,7 @@
 # Funless wrapper for Rust functions
 
 This project contains a small wrapper for Rust functions, ensuring the compatibility with the Wasm runtime in the backend.
-The final Wasm produced receives a JSON string via stdin and returns a JSON string via stdout.
+The final Wasm produced receives a JSON object via stdin and returns a JSON object via stdout.
 
 The `lib_fl` folder contains an example Rust project, respecting the current required constraints for Rust functions.
 

--- a/rust/lib_fl/Cargo.toml
+++ b/rust/lib_fl/Cargo.toml
@@ -22,3 +22,4 @@ crate-type = ["lib"]
 
 [dependencies]
 serde_json = "1.0.85"
+serde = { version = "1.0.145", features = ["derive"] }

--- a/rust/lib_fl/src/lib.rs
+++ b/rust/lib_fl/src/lib.rs
@@ -12,8 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+struct Person {
+    name: String,
+}
+
 pub fn fl_main(body: serde_json::Value) -> serde_json::Value {
-    let parsed_body: String = serde_json::from_value(body).expect("Failed to parse JSON in input");
-    let out = format!("Hello {}!", parsed_body);
-    serde_json::from_str(&format!(r#""{}""#, &out)).expect("Failed to parse JSON in project")
+    let parsed_body: Person = serde_json::from_value(body).expect("Failed to parse JSON in input");
+    let out = format!("Hello {}!", parsed_body.name);
+    serde_json::from_str(&format!(r#"{{"payload": "{}" }}"#, &out))
+        .expect("Failed to parse JSON in project")
 }


### PR DESCRIPTION
This PR changes the example Rust function input and output values from simple strings to JSON dictionaries.

This also adds a simple example of JSON deserialization into a struct.