### PR TITLE
Rust image builder action

### DIFF
--- a/.github/workflows/rust-image-release.yml
+++ b/.github/workflows/rust-image-release.yml
@@ -18,6 +18,7 @@ on:
   push:
     paths:
       - "rust/**"
+      - "!rust/README.md"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/rust-image-release.yml
+++ b/.github/workflows/rust-image-release.yml
@@ -1,0 +1,47 @@
+# Copyright 2022 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Docker Image Release
+
+on:
+  push:
+    paths:
+      - "rust/**"
+  workflow_dispatch:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v3.0.0
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ghcr.io/funlessdev/fl-rust-builder:latest

--- a/.github/workflows/rust-image-release.yml
+++ b/.github/workflows/rust-image-release.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build and push Docker images
         uses: docker/build-push-action@v3.0.0
         with:
-          context: .
+          context: ./rust
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ghcr.io/funlessdev/fl-rust-builder:latest

--- a/rust/.dockerignore
+++ b/rust/.dockerignore
@@ -1,0 +1,5 @@
+lib_fl/
+.gitignore
+Dockerfile
+.dockerignore
+README.md

--- a/rust/.dockerignore
+++ b/rust/.dockerignore
@@ -1,3 +1,17 @@
+# Copyright 2022 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 lib_fl/
 .gitignore
 Dockerfile

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -11,32 +11,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM rust:alpine
+FROM rust:alpine 
 
-RUN apk update && \
-    apk upgrade --no-cache && \
-    apk add --no-cache curl
-
+RUN apk update && apk upgrade --no-cache && apk add --no-cache curl && apk add --no-cache musl-dev && \
+    rustup target add wasm32-wasi && cargo install cargo-wasi
 
 RUN curl -sSLf "$(curl -sSLf https://api.github.com/repos/tomwright/dasel/releases/latest | grep browser_download_url | grep linux_amd64 | grep -v .gz | cut -d\" -f 4)" -L -o dasel && \
     chmod +x dasel && \
     mv ./dasel /bin/dasel
 
-RUN rustup target add wasm32-wasi
-RUN cargo install cargo-wasi
-
-COPY init_script.sh .
-
 WORKDIR /proj
-
 COPY . .
-RUN rm -r ./lib_fl/*
 
 VOLUME ["/lib_fl/"]
 VOLUME ["/out_wasm"]
 
 # copy to destination folder (another mount) with name "code.wasm"
-CMD ["sh", "/init_script.sh"]
+CMD ["sh", "init_script.sh"]
 
 
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -17,11 +17,11 @@ Current constraints:
 
 The docker image requires two volumes:
 
-- The user's function, which will be mounted as `/proj/lib_fl` inside the container
-- An output directory, which will be mounted as `/out_wasm` inside the container
+- The user's function, which needs to be mounted as `/lib_fl` inside the container
+- An output directory, which needs to be mounted as `/out_wasm` inside the container
 
 To produce the `code.wasm` for the example function inside the directory `out_wasm`, the run command would be:
 
 ```
-docker run -v $(pwd)/lib_fl:/lib_fl/ -v $(pwd)/out_wasm:/out_wasm <IMAGE_NAME>
+docker run -v $(pwd)/lib_fl:/lib_fl -v $(pwd)/out_wasm:/out_wasm <IMAGE_NAME>
 ```

--- a/rust/init_script.sh
+++ b/rust/init_script.sh
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 #!/bin/sh
+mkdir /proj/lib_fl
 cp -r /lib_fl/* /proj/lib_fl/
 echo "$(cat /proj/lib_fl/Cargo.toml | dasel put string -r toml 'package.name' 'lib_fl')" > /proj/lib_fl/Cargo.toml
 cargo wasi build --release
-cp /proj/target/wasm32-wasi/release/wrapper.wasm /out_wasm/code.wasm
+mv /proj/target/wasm32-wasi/release/wrapper.wasm /out_wasm/code.wasm


### PR DESCRIPTION
This PR adds the github action that builds the image in the rust folder, everytime there is a change in that folder, as discussed in #8 

 It also adds musl-dev dep in the alpine image to fix a compilation error, plus other small updates.