### PR TITLE
JS image action

### DIFF
--- a/.github/workflows/js-image-release.yml
+++ b/.github/workflows/js-image-release.yml
@@ -44,5 +44,5 @@ jobs:
         with:
           context: ./js
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: ghcr.io/funlessdev/fl-js-builder:latest

--- a/.github/workflows/js-image-release.yml
+++ b/.github/workflows/js-image-release.yml
@@ -1,0 +1,48 @@
+# Copyright 2022 Giuseppe De Palma, Matteo Trentin
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: JS WASM Builder Image Release
+
+on:
+  push:
+    paths:
+      - "js/**"
+      - "js/README.md"
+  workflow_dispatch:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v3.0.0
+        with:
+          context: ./js
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ghcr.io/funlessdev/fl-js-builder:latest

--- a/.github/workflows/rust-image-release.yml
+++ b/.github/workflows/rust-image-release.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Docker Image Release
+name: Rust WASM Builder Image Release
 
 on:
   push:

--- a/.github/workflows/rust-image-release.yml
+++ b/.github/workflows/rust-image-release.yml
@@ -44,5 +44,5 @@ jobs:
         with:
           context: ./rust
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: ghcr.io/funlessdev/fl-rust-builder:latest

--- a/js/.dockerignore
+++ b/js/.dockerignore
@@ -12,12 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/bin/sh
-mkdir /proj/lib_fl
-cp -r /lib_fl/* /proj/lib_fl/
-cd /proj/lib_fl
-npm install
-cd /proj
-parcel build --no-source-maps main.js
-/usr/bin/javy dist/main.js -o code.wasm
-mv /proj/code.wasm /out_wasm/code.wasm
+lib_fl/
+.gitignore
+Dockerfile
+.dockerignore
+README.md

--- a/js/Dockerfile
+++ b/js/Dockerfile
@@ -34,15 +34,11 @@ RUN apt-get update && \
 
 RUN npm install -g parcel
 
-COPY init_script.sh .
-
 WORKDIR /proj
 
 COPY . .
-RUN rm -r ./lib_fl/*
 
 VOLUME ["/lib_fl/"]
 VOLUME ["/out_wasm"]
 
-
-CMD ["sh", "/init_script.sh"]
+CMD ["sh", "init_script.sh"]

--- a/js/README.md
+++ b/js/README.md
@@ -18,8 +18,8 @@ Current constraints:
 
 The docker image requires two volumes:
 
-- The user's function, which will be mounted as `/proj/lib_fl` inside the container
-- An output directory, which will be mounted as `/out_wasm` inside the container
+- The user's function, which needs to be mounted as `/lib_fl` inside the container
+- An output directory, which needs to be mounted as `/out_wasm` inside the container
 
 To produce the `code.wasm` for the example function inside the directory `out_wasm`, the run command would be:
 


### PR DESCRIPTION
This PR closes #8 

It adds the image action release for JS and updates the dockerfile.
It also removes the arm64 platform from the docker build step